### PR TITLE
fix crash when using the french translation

### DIFF
--- a/src/menus.c
+++ b/src/menus.c
@@ -813,7 +813,7 @@ Determine area used by text , so we can draw it centrally
 				if(sy+HUD_FONT_HEIGHT> area->bottom) break;
 			}
 			
-			if (c>=' ' || c<='z') {
+			if (c>=' ' && c<='z') {
 				int topLeftU = 1+((c-32)&15)*16;
 				int topLeftV = 1+((c-32)>>4)*16;
 				int x, y;


### PR DESCRIPTION
the gog release include some translations, the game crash when using the french or the german ones (seems to be related to the use of accents like 'é', 'à', ...)